### PR TITLE
chore: add Code of Conduct, Contributing guide, and PR labeler

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<https://github.com/vimeejs/vimee/issues>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/.github/configs/labeler.yml
+++ b/.github/configs/labeler.yml
@@ -1,0 +1,45 @@
+C-core:
+  - changed-files:
+      - any-glob-to-any-file: packages/core/src/**
+
+C-react:
+  - changed-files:
+      - any-glob-to-any-file: packages/react/src/**
+
+C-plugin-textarea:
+  - changed-files:
+      - any-glob-to-any-file: packages/plugin-textarea/src/**
+
+C-shiki-editor:
+  - changed-files:
+      - any-glob-to-any-file: packages/shiki-editor/src/**
+
+C-testkit:
+  - changed-files:
+      - any-glob-to-any-file: packages/testkit/src/**
+
+A-test:
+  - changed-files:
+      - any-glob-to-any-file: packages/*/src/__tests__/**
+
+A-bench:
+  - changed-files:
+      - any-glob-to-any-file: packages/*/src/benchmarks/**
+
+A-ci:
+  - changed-files:
+      - any-glob-to-any-file: .github/workflows/**
+
+A-docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "!CHANGELOG.md"
+          - "!packages/*/CHANGELOG.md"
+
+A-deps:
+  - changed-files:
+      - any-glob-to-any-file:
+          - package.json
+          - bun.lock
+          - renovate.json

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,0 +1,15 @@
+name: PR Labeler
+
+on: [pull_request_target]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/configs/labeler.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing
+
+Thank you for your interest in contributing to vimee!
+
+Please check out our [good first issues](https://github.com/vimeejs/vimee/contribute) or open a [discussion](https://github.com/vimeejs/vimee/issues) if you need guidance.
+
+We welcome and appreciate any form of contributions.
+
+## Getting Started
+
+```bash
+# Clone
+git clone --recursive https://github.com/vimeejs/vimee.git
+cd vimee
+
+# Install
+bun install
+
+# Build
+bun run build
+
+# Test
+bun run test
+
+# Lint
+bun run lint
+
+# Format
+bun run fmt
+
+# Type check
+bun run typecheck
+```
+
+## Project Structure
+
+```
+packages/
+  core/              # @vimee/core — headless vim engine
+  react/             # @vimee/react — React useVim hook
+  plugin-textarea/   # @vimee/plugin-textarea — vim for any textarea
+  shiki-editor/      # @vimee/shiki-editor — editor component with Shiki
+  testkit/           # @vimee/testkit — test utilities for Vim operations
+```
+
+## Writing Tests
+
+Use `@vimee/testkit` for Vim operation tests:
+
+```ts
+import { vim } from "@vimee/testkit";
+
+const v = vim("hello\nworld");
+v.type("dd");
+expect(v.content()).toBe("world");
+```
+
+See [packages/testkit/README.md](./packages/testkit/README.md) for the full API.
+
+## Commit Convention
+
+```
+<type>(<scope>): <description>
+```
+
+- **Types**: `feat`, `fix`, `test`, `chore`, `ci`, `docs`
+- **Scope**: package name (`core`, `react`, `plugin-textarea`, `shiki-editor`, `testkit`) or omit for root
+- Examples: `feat(core): add mark jumping`, `chore: update deps`
+
+## Before Submitting a PR
+
+1. `bun run test` — all tests must pass
+2. `bun run lint` — no lint errors
+3. `bun run fmt` — code formatted
+4. `bun run typecheck` — no type errors
+
+## AI Usage Policy
+
+When using AI tools (including LLMs like ChatGPT, Claude, Copilot, etc.) to contribute:
+
+- **Please disclose AI usage** to reduce maintainer fatigue
+- **You are responsible** for all AI-generated issues or PRs you submit
+- **Low-quality or unreviewed AI content will be closed immediately**
+
+We encourage the use of AI tools to assist with development, but all contributions must be thoroughly reviewed and tested by the contributor before submission.
+
+## Code of Conduct
+
+Please read our [Code of Conduct](./.github/CODE_OF_CONDUCT.md) before contributing.


### PR DESCRIPTION
## Summary
- Add Contributor Covenant Code of Conduct (`.github/CODE_OF_CONDUCT.md`)
- Add Contributing guide with setup instructions, test examples, commit convention (`CONTRIBUTING.md`)
- Add PR labeler workflow with package-level and category labels (`.github/workflows/pr-labeler.yaml`)

### Labels configured
| Label | Trigger |
|-------|---------|
| `C-core`, `C-react`, `C-plugin-textarea`, `C-shiki-editor`, `C-testkit` | Package source changes |
| `A-test` | Test file changes |
| `A-bench` | Benchmark file changes |
| `A-ci` | Workflow file changes |
| `A-docs` | Markdown file changes |
| `A-deps` | Dependency file changes |

## Test plan
- [x] No code changes, docs and CI config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)