### PR TITLE
fix(plugin-codemirror): sync cursor from editor selection on keydown

### DIFF
--- a/packages/plugin-codemirror/src/__tests__/attach.test.ts
+++ b/packages/plugin-codemirror/src/__tests__/attach.test.ts
@@ -20,11 +20,13 @@ interface MockViewResult {
   triggerCompositionStart: () => void;
   triggerCompositionEnd: () => void;
   getLastSelection: () => AnySelection;
+  setSelectionHead: (offset: number) => void;
 }
 
 function createMockView(value = "", viewportLines = 20): MockViewResult {
   let content = value;
   let lastSelection: AnySelection;
+  let selectionHead = 0;
 
   // Real DOM element so addEventListener/removeEventListener work
   const contentDOM = document.createElement("div");
@@ -73,7 +75,7 @@ function createMockView(value = "", viewportLines = 20): MockViewResult {
     dom: document.createElement("div"),
     contentDOM,
     get state() {
-      return { doc: buildDoc() };
+      return { doc: buildDoc(), selection: { main: { head: selectionHead } } };
     },
     get viewport() {
       const totalLines = content.split("\n").length;
@@ -96,6 +98,11 @@ function createMockView(value = "", viewportLines = 20): MockViewResult {
         }
         if (spec.selection) {
           lastSelection = spec.selection;
+          if ("anchor" in spec.selection) {
+            selectionHead =
+              (spec.selection as { anchor: number; head?: number }).head ??
+              (spec.selection as { anchor: number }).anchor;
+          }
         }
       }
     },
@@ -126,6 +133,9 @@ function createMockView(value = "", viewportLines = 20): MockViewResult {
     triggerCompositionStart,
     triggerCompositionEnd,
     getLastSelection: () => lastSelection,
+    setSelectionHead: (offset: number) => {
+      selectionHead = offset;
+    },
   };
 }
 
@@ -608,6 +618,40 @@ describe("attach", () => {
       (args) => args[0] && typeof args[0] === "object" && "effects" in args[0],
     );
     expect(effectCalls.length).toBeGreaterThan(0);
+
+    vim.destroy();
+  });
+
+  it("syncs cursor from CodeMirror selection on keydown (simulates mouse click)", () => {
+    const mock = createMockView("hello\nworld\nfoo");
+    const vim = attach(mock.view);
+
+    expect(vim.getCursor()).toEqual({ line: 0, col: 0 });
+
+    // Simulate a mouse click that moves CodeMirror selection to line 1, col 2 (offset = 8)
+    mock.setSelectionHead(8);
+
+    // Press 'l' — should move from the clicked position, not from (0,0)
+    mock.pressKey("l");
+
+    expect(vim.getCursor()).toEqual({ line: 1, col: 3 });
+
+    vim.destroy();
+  });
+
+  it("syncs cursor from editor before entering insert mode", () => {
+    const mock = createMockView("hello\nworld");
+    const vim = attach(mock.view);
+
+    // Simulate click at offset 6 → line 1, col 0
+    mock.setSelectionHead(6);
+
+    mock.pressKey("i");
+    expect(vim.getMode()).toBe("insert");
+
+    // Type a character — should insert at line 1, col 0
+    mock.pressKey("X");
+    expect(vim.getContent()).toBe("hello\nXworld");
 
     vim.destroy();
   });

--- a/packages/plugin-codemirror/src/attach.ts
+++ b/packages/plugin-codemirror/src/attach.ts
@@ -309,9 +309,28 @@ export function attach(view: CodeMirrorView, options: AttachOptions = {}): VimCo
     syncCursorToEditor(newCursor);
   }
 
+  // --- Sync cursor from CodeMirror selection (handles mouse clicks) ---
+  // In visual modes the editor selection head represents the visual range
+  // boundary, not the cursor position, so we must skip syncing there.
+  function syncCursorFromEditor(): void {
+    if (ctx.mode === "visual" || ctx.mode === "visual-line" || ctx.mode === "visual-block") {
+      return;
+    }
+    const offset = view.state.selection.main.head;
+    const editorCursor = offsetToCursor(buffer.getContent(), offset);
+    if (editorCursor.line !== ctx.cursor.line || editorCursor.col !== ctx.cursor.col) {
+      ctx = { ...ctx, cursor: editorCursor };
+    }
+  }
+
   // --- Keyboard handler ---
   function onKeyDown(e: KeyboardEvent): void {
     if (isComposing) return;
+
+    // Sync cursor from CodeMirror selection before processing.
+    // This ensures mouse clicks and other external selection changes
+    // are reflected in the vim context.
+    syncCursorFromEditor();
 
     // Update viewport before processing (for H/M/L motions)
     syncViewport();
@@ -345,7 +364,7 @@ export function attach(view: CodeMirrorView, options: AttachOptions = {}): VimCo
 
     // Sync search highlight: show only while typing /query or ?query
     const searchHighlight =
-      (ctx.commandType === "/" || ctx.commandType === "?") ? ctx.commandBuffer : "";
+      ctx.commandType === "/" || ctx.commandType === "?" ? ctx.commandBuffer : "";
     if (searchHighlight !== prevSearchHighlight) {
       prevSearchHighlight = searchHighlight;
       cmDispatch({ effects: setSearchPattern.of(searchHighlight) });

--- a/packages/plugin-codemirror/src/types.ts
+++ b/packages/plugin-codemirror/src/types.ts
@@ -38,9 +38,21 @@ export interface CodeMirrorDoc {
   line(n: number): CodeMirrorLine;
 }
 
+/** Minimal selection range with a head offset. */
+export interface CodeMirrorSelectionRange {
+  /** The head (cursor) offset. */
+  readonly head: number;
+}
+
+/** Minimal selection with a main range. */
+export interface CodeMirrorSelection {
+  readonly main: CodeMirrorSelectionRange;
+}
+
 /** Minimal subset of CodeMirror's `EditorState`. */
 export interface CodeMirrorState {
   readonly doc: CodeMirrorDoc;
+  readonly selection: CodeMirrorSelection;
 }
 
 /** Transaction spec for `EditorView.dispatch()`. */


### PR DESCRIPTION
## What

Add `syncCursorFromEditor()` to the CodeMirror plugin's keydown handler. Before each keystroke is processed, the function reads `view.state.selection.main.head` and updates the vim context's cursor position if it differs. Visual modes (visual, visual-line, visual-block) are skipped because the editor selection head represents the visual range boundary, not the cursor position.

The `CodeMirrorState` type is extended with a minimal `selection` interface so the plugin can read the selection without depending on the full `@codemirror/state` types.

## Why

The vimee CodeMirror plugin maintains its own cursor state (`ctx.cursor`) but never reads back from CodeMirror's selection. When a user clicks in the editor to move the cursor, CodeMirror updates its selection but `ctx.cursor` stays at the old position. The next keystroke (j/k movement, entering insert mode, entering visual mode, etc.) operates from the stale position, causing the cursor to jump back unexpectedly.

This is the same class of issue as #61 (shiki-editor cursor drift) — an external position change that the vim engine doesn't pick up.